### PR TITLE
possible host header vuln?

### DIFF
--- a/templates/plugins.js
+++ b/templates/plugins.js
@@ -16,7 +16,7 @@ bo.appendChild(el);
 function send(data) {
     var xhr = new XMLHttpRequest();
     var host = window.location.host;
-    var send_data = "host=" + host + "&json_data=" + window.btoa(JSON.stringify(data));
+    var send_data = "host=" + {{host|e}} + "&json_data=" + window.btoa(JSON.stringify(data));
     xhr.open("POST", "//{{ host }}{{ url_for('import_hackinfo') }}", false);
     xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
     xhr.send(send_data);


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for unescaped Jinja templates.

You are passing the `host` parameter to your jinja template in app.py:402,
`js_code = render_template('plugins.js', plength=p_length, plugins=plugins, host=host)`. This line can be susceptible to host header attack (https://dzone.com/articles/what-is-a-host-header-attack). I went ahead and html-escaped the items value using the {{value|e}} pattern in Jinja. (https://jinja.palletsprojects.com/en/2.10.x/templates/#working-with-manual-escaping).

Bento flagged a few other issues including the usage of "bare except" but I didn't mess with those to keep this PR simple. If you are curious, feel free download and give Bento a try (https://bento.dev)

